### PR TITLE
Fix release workflow signing key variable names

### DIFF
--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -43,8 +43,7 @@ jobs:
 
     - name: Publish with Gradle
       run: ./gradlew publish
-      env: # Or as an environment variable
-        GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-        GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+      env:
+        # Maven SNAPSHOTS are not signed, so the GPG keys are not loaded from the secret storage in this workflow
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Publish with Gradle
         run: ./gradlew publish
-        env: # Or as an environment variable
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+        env:
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
 


### PR DESCRIPTION
The variable names are outlined here:
https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets

Also, this commit removes the signing keys from the SNAPSHOT publishing workflow as These releases are not signed and thus not needed.