### PR TITLE
Fix broken Maven local publishing

### DIFF
--- a/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
@@ -34,6 +34,16 @@ extensions.configure<MavenPublishBaseExtension> {
 
     coordinates(project.group.toString(), project.name, project.version.toString())
 
+    // Currently, there is an issue with the publishing plugin, preventing us from publishing to the local Maven
+    // repository for testing (see: https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1113).
+    // This is a variant of the workaround described in the link above.
+    project.gradle.taskGraph.whenReady {
+        val taskIsMavenLocal = allTasks.any {
+            it.name == "publishToMavenLocal" || it.path.endsWith("publishToMavenLocal")
+        }
+        project.extensions.getByType<SigningExtension>().isRequired = !taskIsMavenLocal
+    }
+
     pom {
         name.set("fritz2")
         description.set("Easily build reactive web-apps in Kotlin based on flows and coroutines")


### PR DESCRIPTION
Publishing to Maven local is broken in the current version of our publishing plugin. This change implements the suggested workaround until the plugin's bug is fixed.