### PR TITLE
Only apply local Maven publishing workaround to locally run tasks 

### DIFF
--- a/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
@@ -34,16 +34,6 @@ extensions.configure<MavenPublishBaseExtension> {
 
     coordinates(project.group.toString(), project.name, project.version.toString())
 
-    // Currently, there is an issue with the publishing plugin, preventing us from publishing to the local Maven
-    // repository for testing (see: https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1113).
-    // This is a variant of the workaround described in the link above.
-    project.gradle.taskGraph.whenReady {
-        val taskIsMavenLocal = allTasks.any {
-            it.name == "publishToMavenLocal" || it.path.endsWith("publishToMavenLocal")
-        }
-        project.extensions.getByType<SigningExtension>().isRequired = !taskIsMavenLocal
-    }
-
     pom {
         name.set("fritz2")
         description.set("Easily build reactive web-apps in Kotlin based on flows and coroutines")

--- a/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
@@ -41,7 +41,9 @@ extensions.configure<MavenPublishBaseExtension> {
         val taskIsMavenLocal = allTasks.any {
             it.name == "publishToMavenLocal" || it.path.endsWith("publishToMavenLocal")
         }
-        project.extensions.getByType<SigningExtension>().isRequired = !taskIsMavenLocal
+        if (taskIsMavenLocal) {
+            project.extensions.getByType<SigningExtension>().isRequired = false
+        }
     }
 
     pom {

--- a/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev/fritz2/gradle/fritz2-publishing-config.gradle.kts
@@ -34,6 +34,16 @@ extensions.configure<MavenPublishBaseExtension> {
 
     coordinates(project.group.toString(), project.name, project.version.toString())
 
+    // Currently, there is an issue with the publishing plugin, preventing us from publishing to the local Maven
+    // repository for testing (see: https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1113).
+    // This is a variant of the workaround described in the link above.
+    project.gradle.taskGraph.whenReady {
+        val taskIsMavenLocal = allTasks.any {
+            it.name == "publishToMavenLocal" || it.path.endsWith("publishToMavenLocal")
+        }
+        project.extensions.getByType<SigningExtension>().isRequired = !taskIsMavenLocal
+    }
+
     pom {
         name.set("fritz2")
         description.set("Easily build reactive web-apps in Kotlin based on flows and coroutines")


### PR DESCRIPTION
This reverts commit 4055ed53e0aa5a08e5a6dc4efa02378efe285bc3.