### PR TITLE
Configure JVM target via a common conventions plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,6 +7,17 @@ pluginManager.withPlugin(libs.vanniktech.mavenpublishplugin.get().name) {
     version = libs.vanniktech.mavenpublishplugin.get().version!!
 }
 
+/*
+This is one of the _two_ places the JVM version of the project is configured.
+
+All multiplatform modules of this project targeting the JVM apply the `fritz2-jvm-conventions` plugin which configures a
+common toolchain version to use (single point of configuration). The other place is the configuration block below, which
+configures the JVM toolchain for the `buildSrc` module itself.
+ */
+kotlin {
+    jvmToolchain(21)
+}
+
 repositories {
     mavenCentral()
     gradlePluginPortal()

--- a/buildSrc/src/main/kotlin/fritz2-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/fritz2-jvm-conventions.gradle.kts
@@ -1,0 +1,8 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/*
+Configures a common JVM toolchain version for all modules using this conventions plugin.
+ */
+extensions.configure<KotlinMultiplatformExtension> {
+    jvmToolchain(21)
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.jetbrains.dokka)
+    id("fritz2-jvm-conventions")
     id("fritz2-publishing-conventions")
 }
 

--- a/examples/masterdetail/build.gradle.kts
+++ b/examples/masterdetail/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
+    id("fritz2-jvm-conventions")
 }
 
 repositories {

--- a/examples/nestedmodel/build.gradle.kts
+++ b/examples/nestedmodel/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
+    id("fritz2-jvm-conventions")
 }
 
 repositories {

--- a/examples/tictactoe/build.gradle.kts
+++ b/examples/tictactoe/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
+    id("fritz2-jvm-conventions")
 }
 
 repositories {

--- a/examples/todomvc/build.gradle.kts
+++ b/examples/todomvc/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
+    id("fritz2-jvm-conventions")
 }
 
 repositories {

--- a/examples/validation/build.gradle.kts
+++ b/examples/validation/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.google.ksp)
+    id("fritz2-jvm-conventions")
 }
 
 repositories {

--- a/headless-demo/build.gradle.kts
+++ b/headless-demo/build.gradle.kts
@@ -4,6 +4,7 @@ import dev.fritz2.gradle.npm
 plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.google.ksp)
+    id("fritz2-jvm-conventions")
 }
 
 kotlin {

--- a/headless/build.gradle.kts
+++ b/headless/build.gradle.kts
@@ -3,6 +3,7 @@ import dev.fritz2.gradle.npm
 plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.jetbrains.dokka)
+    id("fritz2-jvm-conventions")
     id("fritz2-publishing-conventions")
 }
 

--- a/lenses-annotation-processor/build.gradle.kts
+++ b/lenses-annotation-processor/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.google.ksp)
     alias(libs.plugins.jetbrains.dokka)
+    id("fritz2-jvm-conventions")
     id("fritz2-publishing-conventions")
 }
 

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(libs.plugins.kotlin.multiplatform.get().pluginId)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.jetbrains.dokka)
+    id("fritz2-jvm-conventions")
     id("fritz2-publishing-conventions")
 }
 


### PR DESCRIPTION
This PR introduces a convention plugin that can be used to
automatically configure the JVM target in a multiplatform module
targeting the JVM.

Currently, there is no JVM version configuration in our project,
resulting in inconsistent build results across different machines.

With this convention plugin, the JVM version can be configured via
`buildSrc`, applying to all related modules (see
buildSrc/build.gralde.kts`).

This also eliminates compiler versions about incompatible JVM target
combinations in the `compileKotlin` and `compileJava` tasks.

Additionally, this commit replaces a legacy Java version in the GitHub
worklflow with Java 21.