### PR TITLE
Make RootStore accept initial path

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -32,6 +32,7 @@ public final class dev/fritz2/core/InspectorKt {
 	public static final fun inspectEach (Ldev/fritz2/core/Inspector;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static final fun inspectEach (Ldev/fritz2/core/Inspector;Lkotlin/jvm/functions/Function2;)V
 	public static final fun inspectorOf (Ljava/lang/Object;)Ldev/fritz2/core/Inspector;
+	public static final fun inspectorOf (Ljava/lang/Object;Ljava/lang/String;)Ldev/fritz2/core/Inspector;
 	public static final fun mapByElement (Ldev/fritz2/core/Inspector;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Ldev/fritz2/core/Inspector;
 	public static final fun mapByIndex (Ldev/fritz2/core/Inspector;I)Ldev/fritz2/core/Inspector;
 	public static final fun mapByKey (Ldev/fritz2/core/Inspector;Ljava/lang/Object;)Ldev/fritz2/core/Inspector;
@@ -69,7 +70,8 @@ public abstract interface annotation class dev/fritz2/core/NoLens : java/lang/an
 }
 
 public final class dev/fritz2/core/RootInspector : dev/fritz2/core/Inspector {
-	public fun <init> (Ljava/lang/Object;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getData ()Ljava/lang/Object;
 	public fun getPath ()Ljava/lang/String;
 	public fun map (Ldev/fritz2/core/Lens;)Ldev/fritz2/core/Inspector;

--- a/core/src/commonMain/kotlin/dev/fritz2/core/Inspector.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/Inspector.kt
@@ -38,7 +38,8 @@ interface Inspector<D> {
  *
  * [Inspector] is useful in validation process to know which model attribute is not valid.
  *
- * @property path accepts an initial path. Beware that all parts before the first dot are omitted.
+ * @property path accepts an initial path. Beware that all parts before the first dot are omitted as the path semantics
+ * in fritz2 starts with the part after the "id", which ends at the first dot.
  */
 class RootInspector<T>(
     override val data: T,
@@ -83,7 +84,7 @@ fun <D> Inspector<D?>.mapNull(default: D): Inspector<D> =
  * Creates a new [Inspector] from a _non-nullable_ parent inspector that either contains the original value or `null` if
  * its value matches the given [placeholder].
  *
- * When updating the value of the resulting [Store] to `null`, the [placeholder] is used instead.
+ * When updating the value of the resulting `Store` to `null`, the [placeholder] is used instead.
  * When the resulting [Inspector]'s value would be the [placeholder], `null` will be used instead.
  *
  * @param placeholder value to be mapped to `null`

--- a/core/src/commonMain/kotlin/dev/fritz2/core/Inspector.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/Inspector.kt
@@ -6,6 +6,13 @@ package dev.fritz2.core
 fun <D> inspectorOf(data: D): Inspector<D> = RootInspector(data)
 
 /**
+ *  gives you a new [Inspector] as starting point.
+ *
+ *  @param path optional path. Beware that all parts before the first dot are omitted.
+ */
+fun <D> inspectorOf(data: D, path: String): Inspector<D> = RootInspector(data, path)
+
+/**
  * represents the data and corresponding id of certain value
  * in a deep nested model structure.
  *
@@ -25,17 +32,19 @@ interface Inspector<D> {
     fun <X> map(lens: Lens<D, X>): Inspector<X> = SubInspector(this, lens)
 }
 
-
 /**
  * [RootInspector] is the starting point for getting your [data] and corresponding [path]s from your
  * deep nested model structure. Get this by calling the factory method [inspectorOf].
  *
  * [Inspector] is useful in validation process to know which model attribute is not valid.
+ *
+ * @property path accepts an initial path. Beware that all parts before the first dot are omitted.
  */
 class RootInspector<T>(
-    override val data: T
+    override val data: T,
+    path: String = ""
 ) : Inspector<T> {
-    override val path: String = ""
+    override val path: String = path.substringAfter(".", "").let { if (it.isNotBlank()) ".$it" else "" }
 }
 
 /**

--- a/core/src/commonTest/kotlin/dev/fritz2/core/Inspector.kt
+++ b/core/src/commonTest/kotlin/dev/fritz2/core/Inspector.kt
@@ -247,4 +247,28 @@ class InspectorTests {
             i++
         }
     }
+
+    @Test
+    fun testInspectorOfAcceptsInitialPath() {
+        val result = inspectorOf(42, "Id.one.two")
+        assertEquals(".one.two", result.path)
+    }
+
+    @Test
+    fun testInspectorOfAcceptsBlankInitialPath() {
+        val result = inspectorOf(42, "")
+        assertEquals("", result.path)
+    }
+
+    @Test
+    fun testRootInspectorAcceptsInitialPath() {
+        val result = RootInspector(42, "Id.one.two")
+        assertEquals(".one.two", result.path)
+    }
+
+    @Test
+    fun testRootInspectorAcceptsBlankInitialPath() {
+        val result = inspectorOf(42, "")
+        assertEquals("", result.path)
+    }
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/core/Store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/Store.kt
@@ -142,7 +142,7 @@ open class RootStore<D>(
     job: Job,
     override val id: String = Id.next()
 ) : Store<D> {
-    override val path: String = ""
+    override val path: String by lazy { id.substringAfter(".", "").let { if (it.isNotBlank()) ".$it" else "" } }
 
     private val state: MutableStateFlow<D> = MutableStateFlow(initialData)
     private val queue = Channel<Update<D>>(Channel.UNLIMITED)

--- a/core/src/jsTest/kotlin/dev/fritz2/core/StoreTests.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/StoreTests.kt
@@ -17,7 +17,7 @@ class StoreTests {
 
     @Test
     fun testStoreHandleAndOfferHandler() = runTest {
-        
+
         val id1 = Id.next()
         val id2 = Id.next()
         val buttonId = Id.next()
@@ -68,7 +68,7 @@ class StoreTests {
 
     @Test
     fun testStoreHandleAndOfferHandleAndOfferHandler() = runTest {
-        
+
         val id1 = Id.next()
         val id2 = Id.next()
         val id3 = Id.next()
@@ -137,7 +137,7 @@ class StoreTests {
 
     @Test
     fun testErrorHandling() = runTest {
-        
+
         val valueId = Id.next()
         fun getValue() = document.getElementById(valueId)?.textContent
 
@@ -198,7 +198,11 @@ class StoreTests {
 
         flowOf(1) handledBy store.simpleTestHandlerWithActionThrowingException
         delay(150)
-        assertEquals(store.exceptionSimpleHandlerValue, errorHandlerResult, "exception not caught on simple handler with action")
+        assertEquals(
+            store.exceptionSimpleHandlerValue,
+            errorHandlerResult,
+            "exception not caught on simple handler with action"
+        )
         assertEquals(updates.value, getValue(), "wrong value rendered after simple handler with action")
         checkUpdate("store not updating after simple handler with action")
 
@@ -210,7 +214,11 @@ class StoreTests {
 
         flowOf(2) handledBy store.emittingTestHandlerWithActionThrowingException
         delay(150)
-        assertEquals(store.exceptionEmittingHandlerValue, errorHandlerResult, "exception not caught on emitting handler with action")
+        assertEquals(
+            store.exceptionEmittingHandlerValue,
+            errorHandlerResult,
+            "exception not caught on emitting handler with action"
+        )
         assertEquals(updates.value, getValue(), "wrong value rendered after emitting handler with action")
         checkUpdate("store not updating after emitting handler with action")
 
@@ -234,5 +242,14 @@ class StoreTests {
             resultValue,
             "Data of the derived Store must equal the expected value."
         )
+    }
+
+    @Test
+    fun rootStoresPathWorksCorrectly() {
+        val withoutIdStore = storeOf<String?>(null, job = Job(), id = "")
+        val withInitialPathIdStore = storeOf<String?>(null, job = Job(), id = "Id.one.two")
+
+        assertEquals("", withoutIdStore.path)
+        assertEquals(".one.two", withInitialPathIdStore.path)
     }
 }


### PR DESCRIPTION
- fixes https://github.com/jwstegemann/fritz2/issues/780
- adds an appropriate `inspectorOf`-variant
- enables a RootStore to accept some path (Id + dotted segments after) as initial value. This solves the problem of using a local intermediate store, that syncs with some global model-store and the UI using the original validation messages. Now it is possible to pass the path of the submodel the local store will hold. This way the generated validation messages would also appear on components using the intermediate store.