### PR TITLE
Corrects renaming issue

### DIFF
--- a/www/src/pages/headless/disclosure.md
+++ b/www/src/pages/headless/disclosure.md
@@ -120,7 +120,7 @@ val toggle = storeOf(true, job = Job()) // show Panel at start
 disclosure {
     
     // establish two-way data binding
-    openClose(toggle)
+    openState(toggle)
     
     disclosureButton {
         +"When is being headless a good thing?"

--- a/www/src/pages/headless/headlessComponents.md
+++ b/www/src/pages/headless/headlessComponents.md
@@ -482,7 +482,7 @@ listbox<String> {
     //...
 
     listboxItems {
-        openClose(data = flowOf(true))
+        openState(data = flowOf(true))
 
         characters.forEach { entry ->
             listboxItem(entry) {

--- a/www/src/pages/headless/modal.md
+++ b/www/src/pages/headless/modal.md
@@ -35,7 +35,7 @@ button {
 }
 
 modal {
-    openClose(toggle)
+    openState(toggle)
     modalPanel {
         modalOverlay {
             // add styling and maybe some pleasant transition
@@ -79,7 +79,7 @@ the `setInitialFocus` function can be called inside a `Tag`.
 
 ```kotlin
 modal {
-    openClose(toggle)
+    openState(toggle)
     modalPanel {
         p { +"I am some modal dialog! Press Cancel to exit."}
         // first focusable element
@@ -106,7 +106,7 @@ the factory functions `modalTitle` and `modalDescription`.
 
 ```kotlin
 modal {
-    openClose(toggle)
+    openState(toggle)
     modalPanel {         
         // add title and description
         modalTitle { +"Example Dialog" }
@@ -129,7 +129,7 @@ Showing and hiding the modal dialog can be easily animated with the help of `tra
 
 ```kotlin
 modal {
-    openClose(toggle)
+    openState(toggle)
     modalPanel {
         modalOverlay {
             // some nice fade in/out effect for the overlay


### PR DESCRIPTION
Adapt code examples in headless docs to the changed name of `openState`.

fix https://github.com/jwstegemann/fritz2/issues/940