### PR TITLE
Improve API of ValidatingStore for better Metadata handling and external Validation Triggering

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/validation/Validation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/validation/Validation.kt
@@ -11,37 +11,54 @@ import kotlinx.coroutines.flow.*
  * A [ValidatingStore] is a [Store] which also contains a [Validation] for its model and by default applies it
  * to every update.
  *
- * This store is intentionally configured to validate the data on each update, that is why the [validateAfterUpdate]
- * parameter is set to `true` by default.
+ * You must provide some [metadata], which is reactive and thus by default provided by a [Flow]. There exist an
+ * alternative variant, which accepts a *static* value.
  *
- * There might be special situations where it is reasonable to disable this behaviour by setting [validateAfterUpdate]
+ * This store is intentionally configured to validate the data on each update, that is why the [validateAfterUpdate]
+ * parameter is set to `true` by default. If the [metadata] changes, the validation process is also triggered
+ * automatically.
+ *
+ * Beware that the initial state is not validated. If you want to validate the initial state, you must call the
+ * [validate] handler explicitly.
+ *
+ * There might be special situations where it is reasonable to disable this behavior by setting [validateAfterUpdate]
  * to `false` and to prefer applying the validation individually within custom handlers, for example if a model should
  * only be validated after the user has completed his input or if metadata is needed for the validation process.
- * Then be aware of the fact, that the call of the [validate] function actually updates the [messages] [Flow] already.
+ * Then be aware of the fact, that the call of the [validate] handler actually updates the [messages] [Flow] already.
  *
- * In order for the automatic validation to work, a [metadataDefault] value must be specified. This is needed due to no
- * specific metadata being present during automatic validation. When calling [validate] manually, the appropriate
- * metadata can be supplied directly.
+ * In order for the automatic validation to work, a [metadata] value must be specified. This is needed due to no
+ * specific metadata being present during automatic validation. When calling [validate] handler manually, the
+ * appropriate metadata must be supplied directly.
  *
  * If the new data is not passed to the store's state after validating it, the messages are probably out of sync with
  * the actual store's state!
  * This could lead to false assumptions and might produce hard to detect bugs in your application.
  *
  * @param initialData first current value of this [Store]
- * @param validation [Validation] function to use at the data on this [Store].
- * @param metadataDefault default metadata to be used by the automatic validation (where no explicit values are given)
+ * @property validation [Validation] function to use at the data on this [Store].
+ * @property metadata [Flow] of metadata to be used by the automatic validation. If you habe only a static object,
+ * use the overloaded constrcutor, which supports this too.
  * @param job Job to be used by the [Store]
- * @param validateAfterUpdate flag to decide if a new value gets automatically validated after setting it to the [Store].
- * @param id id of this [Store]. Ids of parent [Store]s will be concatenated.
+ * @property validateAfterUpdate flag to decide if a new value gets automatically validated after setting it to the [Store].
+ * @property id id of this [Store]. Ids of parent [Store]s will be concatenated.
  */
 open class ValidatingStore<D, T, M>(
     initialData: D,
     private val validation: Validation<D, T, M>,
-    private val metadataDefault: T,
+    private val metadata: Flow<T>,
     job: Job,
     private val validateAfterUpdate: Boolean = true,
     override val id: String = Id.next(),
 ) : RootStore<D>(initialData, job, id) {
+
+    constructor(
+        initialData: D,
+        validation: Validation<D, T, M>,
+        metadata: T,
+        job: Job,
+        validateAfterUpdate: Boolean = true,
+        id: String = Id.next(),
+    ) : this(initialData, validation, flowOf(metadata), job, validateAfterUpdate, id)
 
     private val validationMessages: MutableStateFlow<List<M>> = MutableStateFlow(emptyList())
 
@@ -50,6 +67,22 @@ open class ValidatingStore<D, T, M>(
      * Use this [Flow] to render out the validation-messages and to detect the valid state of the current [data] [Flow].
      */
     val messages: Flow<List<M>> = validationMessages.asStateFlow()
+
+    /**
+     * a [Handler] that allows to start a validation and updates the [messages] list.
+     *
+     * If [validateAfterUpdate] is `true`, then this handle gets called automatically on every change of [data]
+     * or [metadata].
+     *
+     * But one can call this also from the outside explicitly!
+     * This is useful in order to validate the initial data for example.
+     */
+    val validate = handle<T> { state, meta ->
+        validate(state, meta).also { validationMessages.value = it }
+        state
+    }
+
+    fun validate(data: D, metadata: T): List<M> = validation(data, metadata)
 
     /**
      * Resets the validation result.
@@ -63,25 +96,8 @@ open class ValidatingStore<D, T, M>(
         validationMessages.value = messages
     }
 
-    /**
-     * Validates the given [data] using the given [metadata], updates the [messages] list and returns them.
-     * If no metadata is specified, [metadataDefault] is used.
-     *
-     * Use this method from inside your [Handler]s to publish
-     * the new state of the validation result via the [messages] flow.
-     *
-     * @param data data to validate
-     * @param metadata metadata for validation
-     * @return [List] of messages
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected fun validate(data: D, metadata: T = metadataDefault): List<M> =
-        validation(data, metadata).also { validationMessages.value = it }
-
     init {
-        if (validateAfterUpdate) data.drop(1) handledBy { newValue ->
-            validate(newValue, metadataDefault)
-        }
+        if (validateAfterUpdate) data.flatMapLatest { metadata }.drop(1) handledBy validate
     }
 }
 
@@ -94,22 +110,42 @@ val <M : ValidationMessage> Flow<List<M>>.valid: Flow<Boolean>
 /**
  * Convenience function to create a simple [ValidatingStore] without any handlers, etc.
  *
- * The created [Store] validates its model after every update automatically.
+ * The created [Store] validates its model after every update of the data or the metadata automatically.
  *
  * @param initialData first current value of this [Store]
  * @param validation [Validation] instance to use at the data on this [Store].
- * @param metadataDefault default metadata to be used by the automatic validation (where no explicit values are given)
+ * @param metadata metadata to be used by the automatic validation
  * @param job Job to be used by the [Store]
  * @param id id of this [Store]. Ids of [SubStore]s will be concatenated.
  */
 fun <D, T, M> storeOf(
     initialData: D,
     validation: Validation<D, T, M>,
-    metadataDefault: T,
+    metadata: Flow<T>,
     job: Job = Job(),
     id: String = Id.next(),
 ): ValidatingStore<D, T, M> =
-    ValidatingStore(initialData, validation, metadataDefault, job, validateAfterUpdate = true, id)
+    ValidatingStore(initialData, validation, metadata, job, validateAfterUpdate = true, id)
+
+/**
+ * Convenience function to create a simple [ValidatingStore] without any handlers, etc.
+ *
+ * The created [Store] validates its model after every update automatically.
+ *
+ * @param initialData first current value of this [Store]
+ * @param validation [Validation] instance to use at the data on this [Store].
+ * @param metadata static metadata to be used by the automatic validation
+ * @param job Job to be used by the [Store]
+ * @param id id of this [Store]. Ids of [SubStore]s will be concatenated.
+ */
+fun <D, T, M> storeOf(
+    initialData: D,
+    validation: Validation<D, T, M>,
+    metadata: T,
+    job: Job = Job(),
+    id: String = Id.next(),
+): ValidatingStore<D, T, M> =
+    ValidatingStore(initialData, validation, metadata, job, validateAfterUpdate = true, id)
 
 /**
  * Convenience function to create a simple [ValidatingStore] without any metadata and handlers.
@@ -132,22 +168,42 @@ fun <D, M> storeOf(
 /**
  * Convenience function to create a simple [ValidatingStore] without any handlers, etc.
  *
- * The created [Store] validates its model after every update automatically.
+ * The created [Store] validates its model after every update of the data or the metadata automatically.
  *
  * @param initialData first current value of this [Store]
  * @param validation [Validation] instance to use at the data on this [Store].
- * @param metadataDefault default metadata to be used by the automatic validation (where no explicit values are given)
+ * @param metadata metadata to be used by the automatic validation
  * @param job Job to be used by the [Store]
  * @param id id of this [Store]. Ids of [SubStore]s will be concatenated.
  */
 fun <D, T, M> WithJob.storeOf(
     initialData: D,
     validation: Validation<D, T, M>,
-    metadataDefault: T,
+    metadata: Flow<T>,
     job: Job = this.job,
     id: String = Id.next(),
 ): ValidatingStore<D, T, M> =
-    ValidatingStore(initialData, validation, metadataDefault, job, validateAfterUpdate = true, id)
+    ValidatingStore(initialData, validation, metadata, job, validateAfterUpdate = true, id)
+
+/**
+ * Convenience function to create a simple [ValidatingStore] without any handlers, etc.
+ *
+ * The created [Store] validates its model after every update automatically.
+ *
+ * @param initialData first current value of this [Store]
+ * @param validation [Validation] instance to use at the data on this [Store].
+ * @param metadata static metadata to be used by the automatic validation
+ * @param job Job to be used by the [Store]
+ * @param id id of this [Store]. Ids of [SubStore]s will be concatenated.
+ */
+fun <D, T, M> WithJob.storeOf(
+    initialData: D,
+    validation: Validation<D, T, M>,
+    metadata: T,
+    job: Job = this.job,
+    id: String = Id.next(),
+): ValidatingStore<D, T, M> =
+    ValidatingStore(initialData, validation, metadata, job, validateAfterUpdate = true, id)
 
 /**
  * Convenience function to create a simple [ValidatingStore] without any metadata and handlers.

--- a/core/src/jsMain/kotlin/dev/fritz2/validation/Validation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/validation/Validation.kt
@@ -37,14 +37,14 @@ import kotlinx.coroutines.flow.*
  * @param initialData first current value of this [Store]
  * @property validation [Validation] function to use at the data on this [Store].
  * @property metadata [Flow] of metadata to be used by the automatic validation. If you habe only a static object,
- * use the overloaded constrcutor, which supports this too.
+ * use the overloaded constructor, which supports this too.
  * @param job Job to be used by the [Store]
  * @property validateAfterUpdate flag to decide if a new value gets automatically validated after setting it to the [Store].
  * @property id id of this [Store]. Ids of parent [Store]s will be concatenated.
  */
 open class ValidatingStore<D, T, M>(
     initialData: D,
-    private val validation: Validation<D, T, M>,
+    protected val validation: Validation<D, T, M>,
     private val metadata: Flow<T>,
     job: Job,
     private val validateAfterUpdate: Boolean = true,
@@ -78,11 +78,9 @@ open class ValidatingStore<D, T, M>(
      * This is useful in order to validate the initial data for example.
      */
     val validate = handle<T> { state, meta ->
-        validate(state, meta).also { validationMessages.value = it }
+        validation(state, meta).also { validationMessages.value = it }
         state
     }
-
-    fun validate(data: D, metadata: T): List<M> = validation(data, metadata)
 
     /**
      * Resets the validation result.

--- a/core/src/jsTest/kotlin/dev/fritz2/validation/ValidationTests.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/validation/ValidationTests.kt
@@ -3,16 +3,230 @@ package dev.fritz2.validation
 import dev.fritz2.core.Id
 import dev.fritz2.core.lensOf
 import dev.fritz2.core.render
+import dev.fritz2.core.storeOf
 import dev.fritz2.runTest
 import dev.fritz2.validation.test.*
 import kotlinx.browser.document
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLSpanElement
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+
+class FactoryFunctionTests {
+    private data class Person(val name: String) {
+        companion object {
+            val validateUnit: Validation<Person, Unit, Message> = validation { inspector ->
+                add(Message("", "Data: ${inspector.data.name}"))
+            }
+
+            val validate: Validation<Person, Int, Message> = validation { inspector, meta ->
+                add(Message("", "Data: ${inspector.data.name}; Meta: $meta"))
+            }
+        }
+    }
+
+    @Test
+    fun testWithJobStoreOfWithFlowMetadataAndDataChangeFirst() = runTest {
+        val storedMeta = storeOf(0)
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validate, metadata = storedMeta.data)
+
+        val id = Id.next()
+        render {
+            div(id = id) {
+                sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+            }
+        }
+
+        delay(100.milliseconds)
+        val divData = document.getElementById(id) as HTMLDivElement
+
+        assertEquals("", divData.textContent)
+
+        sut.update(Person("Fritz II"))
+        delay(100.milliseconds)
+        assertEquals("Data: Fritz II; Meta: 0", divData.textContent)
+
+        storedMeta.update(42)
+        delay(100.milliseconds)
+        assertEquals("Data: Fritz II; Meta: 42", divData.textContent)
+    }
+
+    @Test
+    fun testWithJobStoreOfWithFlowMetadataAndMetaChangeFirst() = runTest {
+        val storedMeta = storeOf(0)
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validate, metadata = storedMeta.data)
+
+        val id = Id.next()
+        render {
+            div(id = id) {
+                sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+            }
+        }
+
+        delay(100.milliseconds)
+        val divData = document.getElementById(id) as HTMLDivElement
+
+        assertEquals("", divData.textContent)
+
+        storedMeta.update(42)
+        delay(100.milliseconds)
+        assertEquals("Data: Chris; Meta: 42", divData.textContent)
+
+        sut.update(Person("Fritz II"))
+        delay(100.milliseconds)
+        assertEquals("Data: Fritz II; Meta: 42", divData.textContent)
+    }
+
+    @Test
+    fun testWithJobStoreOfWithStaticMetadata() = runTest {
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validate, metadata = 42)
+
+        val id = Id.next()
+        render {
+            div(id = id) {
+                sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+            }
+        }
+
+        delay(100.milliseconds)
+        val divData = document.getElementById(id) as HTMLDivElement
+
+        assertEquals("", divData.textContent)
+
+        sut.update(Person("Fritz II"))
+        delay(100.milliseconds)
+        assertEquals("Data: Fritz II; Meta: 42", divData.textContent)
+    }
+
+    @Test
+    fun testWithJobStoreOfWithoutMetadata() = runTest {
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validateUnit)
+
+        val id = Id.next()
+        render {
+            div(id = id) {
+                sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+            }
+        }
+
+        delay(100.milliseconds)
+        val divData = document.getElementById(id) as HTMLDivElement
+
+        assertEquals("", divData.textContent)
+
+        sut.update(Person("Fritz II"))
+        delay(100.milliseconds)
+        assertEquals("Data: Fritz II", divData.textContent)
+    }
+
+    @Test
+    fun testStoreOfWithFlowMetadataAndDataChangeFirst(): dynamic {
+        val job = Job()
+        val storedMeta = storeOf(0, job)
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validate, metadata = storedMeta.data, job)
+
+        return runTest {
+            val id = Id.next()
+            render {
+                div(id = id) {
+                    sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+                }
+            }
+
+            delay(100.milliseconds)
+            val divData = document.getElementById(id) as HTMLDivElement
+
+            assertEquals("", divData.textContent)
+
+            sut.update(Person("Fritz II"))
+            delay(100.milliseconds)
+            assertEquals("Data: Fritz II; Meta: 0", divData.textContent)
+
+            storedMeta.update(42)
+            delay(100.milliseconds)
+            assertEquals("Data: Fritz II; Meta: 42", divData.textContent)
+        }
+    }
+
+    @Test
+    fun testStoreOfWithFlowMetadataAndMetaChangeFirst(): dynamic {
+        val job = Job()
+        val storedMeta = storeOf(0, job)
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validate, metadata = storedMeta.data, job)
+
+        return runTest {
+            val id = Id.next()
+            render {
+                div(id = id) {
+                    sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+                }
+            }
+
+            delay(100.milliseconds)
+            val divData = document.getElementById(id) as HTMLDivElement
+
+            assertEquals("", divData.textContent)
+
+            storedMeta.update(42)
+            delay(100.milliseconds)
+            assertEquals("Data: Chris; Meta: 42", divData.textContent)
+
+            sut.update(Person("Fritz II"))
+            delay(100.milliseconds)
+            assertEquals("Data: Fritz II; Meta: 42", divData.textContent)
+        }
+    }
+
+    @Test
+    fun testStoreOfWithStaticMetadata(): dynamic {
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validate, metadata = 42, Job())
+
+        return runTest {
+            val id = Id.next()
+            render {
+                div(id = id) {
+                    sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+                }
+            }
+
+            delay(100.milliseconds)
+            val divData = document.getElementById(id) as HTMLDivElement
+
+            assertEquals("", divData.textContent)
+
+            sut.update(Person("Fritz II"))
+            delay(100.milliseconds)
+            assertEquals("Data: Fritz II; Meta: 42", divData.textContent)
+        }
+    }
+
+    @Test
+    fun testStoreOfWithoutMetadata(): dynamic {
+        val sut = storeOf(initialData = Person("Chris"), validation = Person.validateUnit, job = Job())
+
+        return runTest {
+            val id = Id.next()
+            render {
+                div(id = id) {
+                    sut.messages.map { messages -> messages.joinToString { it.text } }.renderText(into = this)
+                }
+            }
+
+            delay(100.milliseconds)
+            val divData = document.getElementById(id) as HTMLDivElement
+
+            assertEquals("", divData.textContent)
+
+            sut.update(Person("Fritz II"))
+            delay(100.milliseconds)
+            assertEquals("Data: Fritz II", divData.textContent)
+        }
+    }
+}
 
 class ValidationJSTests {
 
@@ -45,7 +259,7 @@ class ValidationJSTests {
             }
         }
 
-        delay(100)
+        delay(100.milliseconds)
         val divData = document.getElementById(idData) as HTMLDivElement
         val divMessages = document.getElementById(idMessages) as HTMLDivElement
 
@@ -53,7 +267,7 @@ class ValidationJSTests {
         assertEquals(0, divMessages.childElementCount, "there are messages")
 
         store.update(c1)
-        delay(100)
+        delay(100.milliseconds)
 
         assertEquals(c1.name, divData.innerText, "c1: car name has not changed")
         assertEquals(3, divMessages.childElementCount, "c1: there is not 3 message")
@@ -64,7 +278,7 @@ class ValidationJSTests {
         )
 
         store.update(c2)
-        delay(100)
+        delay(100.milliseconds)
 
         assertEquals(c2.name, divData.innerText, "c2: car name has changed")
         assertEquals(3, divMessages.childElementCount, "c2: there is not 3 message")
@@ -75,7 +289,7 @@ class ValidationJSTests {
         )
 
         store.update(c3)
-        delay(100)
+        delay(100.milliseconds)
 
         assertEquals(c3.name, divData.innerText, "c3: car name has changed")
         assertEquals(2, divMessages.childElementCount, "c3: there is not 3 message")
@@ -140,7 +354,7 @@ class ValidationJSTests {
         }
 
         // Test Intermediate Level (color-Field of Car)
-        delay(100)
+        delay(100.milliseconds)
         val divData = document.getElementById(idData) as HTMLDivElement
         val divMessagesIntermediateLevel = document.getElementById(idMessagesIntermediateLevel) as HTMLDivElement
         val divPathIntermediateLevel = document.getElementById(idPathIntermediateLevel) as HTMLDivElement
@@ -152,7 +366,7 @@ class ValidationJSTests {
         assertEquals(0, divMessagesIntermediateLevel.childElementCount, "there are messages")
 
         store.update(Car("car1", Color(-1, -1, -1)))
-        delay(100)
+        delay(100.milliseconds)
 
         assertEquals("-1, -1, -1", divData.textContent, "c1: car color has not changed")
         assertEquals(3, divMessagesIntermediateLevel.childElementCount, "c1: there is not 3 message")
@@ -207,18 +421,19 @@ class MessageFilterTests {
     fun testMessagesWithoutFilterExpressionOnlyMatchesExactlyFittingPathes() = runTest {
         val initial = Foo("", "", Bar("", ""))
         val store = storeOf(initial, validation = Foo.validate)
+        delay(100.milliseconds)
         store.update(initial.copy(foo = "a"))
 
         val id = Id.next()
         render {
             span(id = id) {
                 store.map(Foo.barLens).messages<Message>()
-                    ?.mapNotNull { messages -> messages.joinToString { it.text } }
+                    ?.map { messages -> messages.joinToString { it.text } }
                     ?.renderText()
             }
         }
 
-        delay(100)
+        delay(100.milliseconds)
         val span = document.getElementById(id) as HTMLSpanElement
         assertEquals("bar ist falsch", span.textContent)
     }
@@ -227,16 +442,17 @@ class MessageFilterTests {
     fun testMessagesOfSubTreeMatchesAllSubPathes() = runTest {
         val initial = Foo("", "", Bar("", ""))
         val store = storeOf(initial, validation = Foo.validate)
+        delay(100.milliseconds)
         store.update(initial.copy(foo = "a"))
 
         val id = Id.next()
         render {
             span(id = id) {
-                store.map(Foo.barLens).messagesOfSubModel<Message>()?.mapNotNull { it.size.toString() }?.renderText()
+                store.map(Foo.barLens).messagesOfSubModel<Message>()?.map { it.size.toString() }?.renderText()
             }
         }
 
-        delay(100)
+        delay(100.milliseconds)
         val span = document.getElementById(id) as HTMLSpanElement
         assertEquals("3", span.textContent)
     }
@@ -245,6 +461,7 @@ class MessageFilterTests {
     fun testMessagesRespectFilterExpression() = runTest {
         val initial = Foo("", "", Bar("", ""))
         val store = storeOf(initial, validation = Foo.validate)
+        delay(100.milliseconds)
         store.update(initial.copy(foo = "a"))
 
         val id = Id.next()
@@ -252,16 +469,16 @@ class MessageFilterTests {
             span(id = id) {
                 // 4
                 store.map(Foo.barLens).messages<Message> { it.text.contains("foo") }
-                    ?.mapNotNull { it.size.toString() }
+                    ?.map { it.size.toString() }
                     ?.renderText()
                 // 0
                 store.map(Foo.barLens).messages<Message> { it.text.contains("richtig") }
-                    ?.mapNotNull { it.size.toString() }
+                    ?.map { it.size.toString() }
                     ?.renderText()
             }
         }
 
-        delay(100)
+        delay(100.milliseconds)
         val span = document.getElementById(id) as HTMLSpanElement
         assertEquals("40", span.textContent)
     }
@@ -270,6 +487,7 @@ class MessageFilterTests {
     fun testOverlappingFieldnamesDoNotMatchEachOthersPathes() = runTest {
         val initial = Foo("", "", Bar("", ""))
         val store = storeOf(initial, validation = Foo.validate)
+        delay(100.milliseconds)
         store.update(initial.copy(foo = "a"))
         /*
         Validation should result in messages with these pathes:
@@ -298,7 +516,7 @@ class MessageFilterTests {
             }
         }
 
-        delay(100)
+        delay(100.milliseconds)
         val span = document.getElementById(id) as HTMLSpanElement
         assertEquals("11311", span.textContent)
     }

--- a/examples/validation/src/jsMain/kotlin/dev/fritz2/examples/validation/Validation.kt
+++ b/examples/validation/src/jsMain/kotlin/dev/fritz2/examples/validation/Validation.kt
@@ -24,7 +24,7 @@ object PersonStore : ValidatingStore<Person, Unit, Message>(
     Person(), personValidator, Unit, Job(), id = Person.id
 ) {
     val save = handle { person ->
-        if (validate(person, Unit).valid) {
+        if (validation(person, Unit).valid) {
             PersonListStore.add(person)
             cleanUpValMessages()
             Person()

--- a/www/src/pages/docs/60_Validation.md
+++ b/www/src/pages/docs/60_Validation.md
@@ -134,7 +134,7 @@ type. Handle this `Flow` like any other `Flow` of a `List` — for example, rend
 
 ```kotlin
 // create a `ValidatingStore` by using an overloaded factory located in `dev.fritz2.validation`-package
-val store = storeOf(Person("Chris", 48), Person::validate)
+val store = storeOf(Person("Chris", 48), Person.validate)
 
 // create some messages with shady data
 store.update(Person("", 101))
@@ -395,20 +395,24 @@ If you require more than just a simple `Enum`, you should create a **dedicated**
 all the necessary data.
 :::
 
-### Dealing with reactive Metadata and ValidatingStore
+### Dealing with Metadata and ValidatingStore
 
 Now that you are familiar with [integrating validation](#integrate-validation-into-stores) into a `Store` using
 the specialized `ValidatingStore` and understand the motivation [behind metadata](#using-metadata) in validation, 
 it is time to discuss how to use both together.
 
-There is a significant difference between static metadata — those that do not change during the course of an 
-application's use — and those that actually change analogously to the state of an application and are therefore
-potentially different with each validation run.
+fritz2 offers support for both static and reactive metadata. In practice, the latter often play a crucial role, 
+as applications frequently build up their data model over a series of steps, 
+resulting in parts that cannot be valid yet. Typically, you do not want to display messages for these sections yet. 
+In this regard, the so-called UI state often plays an important role in validation; consequently, 
+it exists as part of the overall data model within a store and must be handled reactively.
 
-Let's first look at the simpler case where the metadata is static and possibly only depends on the configuration
-of the application instance.
+But sometimes metadata actually only exists as static data; in web applications, this might be data that is guaranteed 
+to remain constant throughout the duration of a session.
 
-We will continue using the example from the previous section.
+We will first consider the static case.
+
+We will simply continue using the example from the previous sections.
 
 We first create two data sets:
 - a valid person
@@ -441,10 +445,13 @@ val invalidChris = chris.copy(
 
 With this, we can create a store:
 ```kotlin
-val storedPerson = ValidatingStore(chris, Person.validate, Progress.Address, Job())
-//                                                         ^^^^^^^^^^^^^^^^
-//                                                         We must pass initial metadata
-//                                                         We chose the maximum progress to see all messages
+// we import the new factory from the `validation`-package!
+import dev.fritz2.validation.storeOf
+
+val storedPerson = storeOf(chris, Person.validate, Progress.Address, Job())
+//                                                 ^^^^^^^^^^^^^^^^
+//                                                 We must pass initial metadata
+//                                                 We chose the maximum progress to see all messages
 ```
 
 Note that the metadata we pass in the constructor is used for all validations. They are therefore static over the 
@@ -453,7 +460,7 @@ entire lifetime of the store.
 We can demonstrate the validation with the following minimal UI:
 ```kotlin
 render {
-    val storedPerson = ValidatingStore(chris, Person.validate, Progress.Address, job)
+    val storedPerson = storeOf(chris, Person.validate, Progress.Address)
 
     button {
         +"Set invalid Data"
@@ -480,35 +487,17 @@ Message(path=.addresses.0.street, severity=Error, text=Please provide a street)
 As a rule, however, metadata will not be static, but — just like the functional data — will be dynamically dependent 
 on the user's actions. So how can we use such dynamic metadata for validations?
 
-We must derive our own type from `ValidatingStore` and implement handlers within it that call the following function:
-```kotlin
-protected fun validate(data: D, metadata: T = metadataDefault): List<M>
-```
+There also is a *factory* for this case - in fact the primary constructor of the `ValidatingStore`, which is called 
+internally, takes a `Flow<T>` as ist default type.
 
-The following implementation allows injecting a `Progress` value to call the validation with this metadata set:
+Now we still need a store for the UI state — in our example, the `Progress` — and we must pass its `data`-flow to the
+validating store factory:
 ```kotlin
-val storedPerson = object : ValidatingStore<Person, Progress, Message>(
-    invalidChris, Person.validate, Progress.Core, job
-) {
-    val validate = handle<Progress> { state, progress ->
-    //                    ^^^^^^^^           ^^^^^^^^
-    //                    Enable to pass a `Progress`-object
-        
-        validate(state, progress)
-        //              ^^^^^^^^
-        //              pass the Progress-object into the actual validation
-        state
-    }
-}
-```
-
-Now we still need a store for the UI state — in our example, the `Progress` — and we must connect its reactive 
-state with the handler created above:
-```kotlin
-val storedProgress = storeOf(Progress.Core, job)
-
-// here the "magic" happens: the changed Progress will trigger a new validation
-storedProgress.data handledBy storedPerson.validate
+val storedProgress = storeOf(Progress.Core)
+val storedPerson = storeOf(invalidChris, Person2.validate, storedProgress.data)
+//                                                         ^^^^^^^^^^^^^^^^^^^
+//                                                         we pass a `Flow` of `Progress`, so each new value
+//                                                         on the flow will retrigger the `validate` handler
 ```
 
 Now we can slightly adjust the example: We change the button so that it toggles the current progress back and forth 
@@ -549,8 +538,11 @@ Message(path=.addresses.0.street, severity=Error, text=Please provide a street)
 ```
 
 :::info
-Of course, you can pass the metadata into the `Handler` in any way intended by fritz2, e.g., through an event
-triggered by the user, such as clicking a "Next" button or similar.
+Of course, you can can call the `public validate` handler manually and pass the metadata into the `Handler` in any way
+intended by fritz2, e.g., through an event triggered by the user, such as clicking a "Next" button or similar.
+
+If you disable the `validateAfterUpdate` flag in the constructor of `ValidatingStore`, you even must call this
+by yourself in order to fill and keep the `messages`-flow up to date.
 :::
 
 ### Summary of Inspector-Mappings


### PR DESCRIPTION
- add support for reactive metatdata: `ValidatingStore` now accepts and acts upon a `Flow<T>`
- either changing the state of the store or the metadata value will automatically retrigger the `validate` handler.
- exposes a `public` `validate` handler, that allows the user to manually trigger a validation.
- exposes a `validate`-method, which only executes the given `Validation`. This enables the user to check for validity in advance. Beware that this method is pure - so no state is changed and no message of the `messages`-flow will be updated.
- add unittests for all `storeOf`-factories of the `ValidatingStore`. Check the intended behavior as well.
- adapt the corresponding documentation part as well.

fix https://github.com/jwstegemann/fritz2/issues/948