### PR TITLE
Adds new `handle`-factories to support call-chains

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/Store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/Store.kt
@@ -116,6 +116,38 @@ interface Store<D> {
         })
 
     /**
+     * factory method to create an [EmittingHandler] taking an action-value and the current store value but does
+     * not derive a new value from both. The actual value is just passed through, so it is all about dealing
+     * with some *side effect* by calling the [FlowCollector.emit] function from within the [execute] parameter.
+     *
+     * @see handleAndEmit
+     *
+     * @param execute lambda that is executed for each action-value on the connected [Flow]. You should emit values
+     * from this lambda.
+     */
+    fun <A, E> handleOnlyEmit(execute: suspend FlowCollector<E>.(D, A) -> Unit): EmittingHandler<A, E> =
+        handleAndEmit { state, payload ->
+            execute(state, payload)
+            state
+        }
+
+    /**
+     * factory method to create an [EmittingHandler] taking the current store value but does not derive a new value
+     * from it. The actual value is just passed through, so it is all about dealing with some *side effect*
+     * by calling the [FlowCollector.emit] function from within the [execute] parameter.
+     *
+     * @see handleAndEmit
+     *
+     * @param execute lambda that is executed for each action-value on the connected [Flow]. You should emit values
+     * from this lambda.
+     */
+    fun <E> handleOnlyEmit(execute: suspend FlowCollector<E>.(D) -> Unit): EmittingHandler<Unit, E> =
+        handleAndEmit { state, payload ->
+            execute(state)
+            state
+        }
+
+    /**
      * Default error handler printing the error to console.
      *
      * @param cause Throwable to handle

--- a/core/src/jsTest/kotlin/dev/fritz2/core/StoreTests.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/StoreTests.kt
@@ -252,4 +252,112 @@ class StoreTests {
         assertEquals("", withoutIdStore.path)
         assertEquals(".one.two", withInitialPathIdStore.path)
     }
+
+    @Test
+    fun handleOnlyEmit_DoesNotChangeTheStateAndEmitsValues() = runTest {
+        val idData = Id.next()
+        val idResult = Id.next()
+        val buttonUpdateId = Id.next()
+        val buttonTriggerId = Id.next()
+        val buttonTriggerUnitId = Id.next()
+
+        val storedResult = storeOf("")
+
+        val storedData = object : RootStore<String>("initial", job = Job()) {
+            val trigger = handleOnlyEmit<String, String> { state, action ->
+                // only forwards the action; no update of the state!
+                emit("$state -> $action")
+            }
+
+            val triggerUnit = handleOnlyEmit<String> { state ->
+                // only forwards the action; no update of the state!
+                emit("$state -> Unit")
+            }
+
+            init {
+                trigger handledBy storedResult.update
+                triggerUnit handledBy storedResult.update
+            }
+        }
+
+        render {
+            section {
+                div(id = idData) {
+                    // should only change after update but NOT after triggering!
+                    storedData.data.renderText()
+                }
+                div(id = idResult) {
+                    // must change after triggering
+                    storedResult.data.renderText()
+                }
+                button(id = buttonTriggerId) {
+                    clicks.map { "clicked" } handledBy storedData.trigger
+                }
+                button(id = buttonUpdateId) {
+                    clicks.map { "updated" } handledBy storedData.update
+                }
+                button(id = buttonTriggerUnitId) {
+                    clicks handledBy storedData.triggerUnit
+                }
+            }
+        }
+
+        delay(100)
+
+        val buttonTrigger = document.getElementById(buttonTriggerId) as HTMLButtonElement
+        val buttonTriggerUnit = document.getElementById(buttonTriggerUnitId) as HTMLButtonElement
+        val buttonUpdate = document.getElementById(buttonUpdateId) as HTMLButtonElement
+        val divData = document.getElementById(idData) as HTMLDivElement
+        val divResult = document.getElementById(idResult) as HTMLDivElement
+
+        assertEquals(
+            "initial", divData.textContent,
+            "textContent of divData is not same like 'initial'"
+        )
+        assertEquals(
+            "", divResult.textContent,
+            "textContent of divResult is not empty"
+        )
+
+        buttonTrigger.click()
+        delay(100)
+
+        assertEquals(
+            "initial", divData.textContent,
+            "textContent of divData is not same like 'initial'"
+        )
+        assertEquals(
+            "initial -> clicked",
+            divResult.textContent,
+            "textContent of divResult is not 'initial -> clicked'"
+        )
+
+        buttonUpdate.click()
+        delay(100)
+        buttonTrigger.click()
+        delay(100)
+
+        assertEquals(
+            "updated", divData.textContent,
+            "textContent of divData is not same like 'updated'"
+        )
+        assertEquals(
+            "updated -> clicked",
+            divResult.textContent,
+            "textContent of divResult is not 'updated -> clicked'"
+        )
+
+        buttonTriggerUnit.click()
+        delay(100)
+
+        assertEquals(
+            "updated", divData.textContent,
+            "textContent of divData is not same like 'updated'"
+        )
+        assertEquals(
+            "updated -> Unit",
+            divResult.textContent,
+            "textContent of divResult is not 'updated -> Unit'"
+        )
+    }
 }


### PR DESCRIPTION
- adds the `EmittingHandler`-factories `handleOnlyEmit` for some action payload or `Unit` as special variant
- those will not update the store's state
- they should only be used to call `emit` inside to propagate the action or some derived value of the action with the current state to some other `Flow`-Handling.
- this is useful for patterns, where the result of some decision dialog may result in different workflows but should end up in the updated model finally. It is very important in such scenarios, that the intermediate model never updates the store's state, other Flow-Handler-combos would consume the new value too early, as the final model state is not reached yet.
- the described behaviour can be achieved already with the `handleAndEmit`-factory of course. But this requires *discipline* in not changing the original state and return some updated model to the store. Experience show that this is a potential trap and can produce false behavior, which is then hard to find. This explicit function and the `Unit`-return type prohibits to update the store's state by design.